### PR TITLE
Improve Travis CI setting and assertions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - 7.3
+  - 7.4
 
 before_script:
   - travis_retry composer install --prefer-dist --no-interaction

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -7,13 +7,13 @@ class HelperTest extends TestCase
     /** @test */
     public function it_has_helper_file()
     {
-        $this->assertTrue(file_exists(dirname(dirname(__FILE__)) . '/src/Support/helpers.php'));
+        $this->assertFileExists(dirname(dirname(__FILE__)) . '/src/Support/helpers.php');
     }
 
     /** @test */
     public function it_has_helper_config_file()
     {
-        $this->assertTrue(file_exists(dirname(dirname(__FILE__)) . '/config/helper.php'));
+        $this->assertFileExists(dirname(dirname(__FILE__)) . '/config/helper.php');
     }
 
     /** @test */


### PR DESCRIPTION
# Changed log

- Add `php-7.4` version test during Travis CI build.
- Using the `assertFileExists` to assert expected file path is existed.